### PR TITLE
Add configurable system-wide password policy

### DIFF
--- a/common-util/src/main/java/dev/getelements/elements/config/CommonModuleDefaults.java
+++ b/common-util/src/main/java/dev/getelements/elements/config/CommonModuleDefaults.java
@@ -23,6 +23,8 @@ public class CommonModuleDefaults implements ModuleDefaults {
         defaultProperties.setProperty(ASYNC_TIMEOUT_LIMIT, Integer.toString(0));
         defaultProperties.setProperty(GENERATED_PASSWORD_LENGTH, "24");
         defaultProperties.setProperty(GLOBAL_SECRET, "");
+        defaultProperties.setProperty(PASSWORD_POLICY_REGEX, ".{4,}");
+        defaultProperties.setProperty(PASSWORD_POLICY_DESCRIPTION, "Password must be at least 4 characters.");
 
         // The way the dependent code uses this is a little weird and should be reworked to eliminate some redundancy.
         defaultProperties.setProperty(APP_OUTSIDE_URL, "http://localhost:8080/");

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/Constants.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/Constants.java
@@ -119,6 +119,21 @@ public interface Constants {
     String GENERATED_PASSWORD_LENGTH = "dev.getelements.elements.mock.generated.password.length";
 
     /**
+     * The system-wide password policy, expressed as a regex a submitted password must fully match.
+     * Enforced everywhere a password is accepted or changed (signup, password reset, admin-set
+     * password, email/username-password linking). Does not apply to server-generated passwords.
+     */
+    String PASSWORD_POLICY_REGEX = "dev.getelements.elements.password.policy.regex";
+
+    /**
+     * A plain-text, human-readable description of {@link #PASSWORD_POLICY_REGEX}, so clients can
+     * display the requirement to end users without parsing the regex themselves. Also included in
+     * the validation error message when a submitted password fails the policy. Operators are
+     * responsible for keeping this in sync with the regex.
+     */
+    String PASSWORD_POLICY_DESCRIPTION = "dev.getelements.elements.password.policy.description";
+
+    /**
      * Defines some useful regex patterns.
      */
     interface Regexp {

--- a/service-test/src/test/java/dev/getelements/elements/service/user/EmailPasswordLinkServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/user/EmailPasswordLinkServiceTest.java
@@ -13,7 +13,10 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static com.google.inject.Guice.createInjector;
+import static com.google.inject.name.Names.named;
 import static dev.getelements.elements.sdk.dao.UserUidDao.SCHEME_EMAIL;
+import static dev.getelements.elements.sdk.model.Constants.PASSWORD_POLICY_DESCRIPTION;
+import static dev.getelements.elements.sdk.model.Constants.PASSWORD_POLICY_REGEX;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 
@@ -99,6 +102,8 @@ public class EmailPasswordLinkServiceTest {
             bind(User.class).toInstance(currentUser);
             bind(UserDao.class).toInstance(mock(UserDao.class));
             bind(UserUidDao.class).toInstance(mock(UserUidDao.class));
+            bindConstant().annotatedWith(named(PASSWORD_POLICY_REGEX)).to(".*");
+            bindConstant().annotatedWith(named(PASSWORD_POLICY_DESCRIPTION)).to("");
         }
     }
 

--- a/service-test/src/test/java/dev/getelements/elements/service/user/PasswordResetServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/user/PasswordResetServiceTest.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 import static com.google.inject.Guice.createInjector;
 import static com.google.inject.name.Names.named;
 import static dev.getelements.elements.sdk.dao.UserUidDao.SCHEME_EMAIL;
+import static dev.getelements.elements.sdk.model.Constants.PASSWORD_POLICY_DESCRIPTION;
+import static dev.getelements.elements.sdk.model.Constants.PASSWORD_POLICY_REGEX;
 import static dev.getelements.elements.sdk.service.user.PasswordResetService.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -239,6 +241,8 @@ public class PasswordResetServiceTest {
             bind(PasswordResetTokenDao.class).toInstance(mock(PasswordResetTokenDao.class));
             bind(EmailService.class).toInstance(mock(EmailService.class));
             bind(ElementRegistry.class).toInstance(mock(ElementRegistry.class));
+            bindConstant().annotatedWith(named(PASSWORD_POLICY_REGEX)).to(".*");
+            bindConstant().annotatedWith(named(PASSWORD_POLICY_DESCRIPTION)).to("");
 
             bindConstant().annotatedWith(named(RESET_EMAIL_SUBJECT)).to(SUBJECT);
             bindConstant().annotatedWith(named(RESET_EMAIL_TEMPLATE)).to(TEMPLATE);

--- a/service-test/src/test/java/dev/getelements/elements/service/user/UsernamePasswordLinkServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/user/UsernamePasswordLinkServiceTest.java
@@ -16,7 +16,10 @@ import org.testng.annotations.Test;
 import java.util.function.Function;
 
 import static com.google.inject.Guice.createInjector;
+import static com.google.inject.name.Names.named;
 import static dev.getelements.elements.sdk.dao.UserUidDao.SCHEME_NAME;
+import static dev.getelements.elements.sdk.model.Constants.PASSWORD_POLICY_DESCRIPTION;
+import static dev.getelements.elements.sdk.model.Constants.PASSWORD_POLICY_REGEX;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -135,6 +138,8 @@ public class UsernamePasswordLinkServiceTest {
             bind(User.class).toInstance(currentUser);
             bind(UserDao.class).toInstance(mock(UserDao.class));
             bind(UserUidDao.class).toInstance(mock(UserUidDao.class));
+            bindConstant().annotatedWith(named(PASSWORD_POLICY_REGEX)).to(".*");
+            bindConstant().annotatedWith(named(PASSWORD_POLICY_DESCRIPTION)).to("");
             // Binding Transaction also satisfies Provider<Transaction> injection automatically.
             bind(Transaction.class).toInstance(tx);
         }

--- a/service/src/main/java/dev/getelements/elements/service/user/AbstractPasswordResetService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/AbstractPasswordResetService.java
@@ -49,6 +49,8 @@ abstract class AbstractPasswordResetService implements PasswordResetService {
 
     private String expiryHours;
 
+    private PasswordPolicyValidator passwordPolicyValidator;
+
     // -------------------------------------------------------------------------
     // Shared core operations
     // -------------------------------------------------------------------------
@@ -103,6 +105,7 @@ abstract class AbstractPasswordResetService implements PasswordResetService {
         final var tokenData = getTokenDao().findToken(token)
                 .orElseThrow(() -> new InvalidParameterException("Invalid or expired reset token."));
 
+        getPasswordPolicyValidator().validate(newPassword);
         getUserDao().setPassword(tokenData.getUser().getId(), newPassword);
         getTokenDao().deleteToken(token);
 
@@ -193,6 +196,15 @@ abstract class AbstractPasswordResetService implements PasswordResetService {
         } catch (final NumberFormatException e) {
             return TimeUnit.HOURS.toMillis(DEFAULT_TOKEN_VALIDITY_HOURS);
         }
+    }
+
+    public PasswordPolicyValidator getPasswordPolicyValidator() {
+        return passwordPolicyValidator;
+    }
+
+    @Inject
+    public void setPasswordPolicyValidator(PasswordPolicyValidator passwordPolicyValidator) {
+        this.passwordPolicyValidator = passwordPolicyValidator;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/user/AnonUserService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/AnonUserService.java
@@ -24,6 +24,8 @@ public class AnonUserService extends AbstractUserService implements UserService 
 
     private PasswordGenerator passwordGenerator;
 
+    private PasswordPolicyValidator passwordPolicyValidator;
+
     @Override
     public User getUser(String userId)  {
         throw new ForbiddenException();
@@ -49,9 +51,14 @@ public class AnonUserService extends AbstractUserService implements UserService 
 
         getNameService().assignNameAndEmailIfNecessary(user);
 
-        final var password = isNullOrEmpty(userCreateRequest.getPassword())
-            ? getPasswordGenerator().generate()
-            : userCreateRequest.getPassword();
+        final String password;
+
+        if (isNullOrEmpty(userCreateRequest.getPassword())) {
+            password = getPasswordGenerator().generate();
+        } else {
+            getPasswordPolicyValidator().validate(userCreateRequest.getPassword());
+            password = userCreateRequest.getPassword();
+        }
 
         final var created = getUserDao().createUserWithPasswordStrict(user, password);
 
@@ -116,6 +123,15 @@ public class AnonUserService extends AbstractUserService implements UserService 
     @Inject
     public void setPasswordGenerator(PasswordGenerator passwordGenerator) {
         this.passwordGenerator = passwordGenerator;
+    }
+
+    public PasswordPolicyValidator getPasswordPolicyValidator() {
+        return passwordPolicyValidator;
+    }
+
+    @Inject
+    public void setPasswordPolicyValidator(PasswordPolicyValidator passwordPolicyValidator) {
+        this.passwordPolicyValidator = passwordPolicyValidator;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/user/PasswordPolicyValidator.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/PasswordPolicyValidator.java
@@ -1,0 +1,70 @@
+package dev.getelements.elements.service.user;
+
+import dev.getelements.elements.sdk.model.exception.InvalidParameterException;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static dev.getelements.elements.sdk.model.Constants.PASSWORD_POLICY_DESCRIPTION;
+import static dev.getelements.elements.sdk.model.Constants.PASSWORD_POLICY_REGEX;
+
+/**
+ * Enforces the system-wide, deploy-time-configured password policy against a raw, client-submitted
+ * password. Not applied to server-generated passwords (e.g. mock/bootstrap accounts), which are not
+ * subject to end-user policy requirements.
+ */
+@Singleton
+public class PasswordPolicyValidator {
+
+    private String policyRegex;
+
+    private String policyDescription;
+
+    /**
+     * Validates the supplied raw password against the configured policy regex.
+     *
+     * @param rawPassword the raw, plain-text password to validate
+     * @throws InvalidParameterException if the password does not match the configured policy, with a
+     *                                   message including the configured policy description
+     */
+    public void validate(final String rawPassword) {
+
+        final Pattern pattern;
+
+        try {
+            pattern = Pattern.compile(getPolicyRegex());
+        } catch (final PatternSyntaxException ex) {
+            // A misconfigured operator-supplied regex should not silently disable the policy nor
+            // reject every password; surface the misconfiguration instead.
+            throw new IllegalStateException(
+                    "Configured password policy regex is invalid: " + getPolicyRegex(), ex);
+        }
+
+        if (rawPassword == null || !pattern.matcher(rawPassword).matches()) {
+            throw new InvalidParameterException(getPolicyDescription());
+        }
+
+    }
+
+    public String getPolicyRegex() {
+        return policyRegex;
+    }
+
+    @Inject
+    public void setPolicyRegex(@Named(PASSWORD_POLICY_REGEX) String policyRegex) {
+        this.policyRegex = policyRegex;
+    }
+
+    public String getPolicyDescription() {
+        return policyDescription;
+    }
+
+    @Inject
+    public void setPolicyDescription(@Named(PASSWORD_POLICY_DESCRIPTION) String policyDescription) {
+        this.policyDescription = policyDescription;
+    }
+
+}

--- a/service/src/main/java/dev/getelements/elements/service/user/SuperUserEmailPasswordLinkService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/SuperUserEmailPasswordLinkService.java
@@ -23,6 +23,8 @@ public class SuperUserEmailPasswordLinkService implements EmailPasswordLinkServi
 
     private UserUidDao userUidDao;
 
+    private PasswordPolicyValidator passwordPolicyValidator;
+
     @Override
     public User linkEmailPassword(final String email, final String password) {
         final var normalizedEmail = email.trim().toLowerCase();
@@ -33,6 +35,8 @@ public class SuperUserEmailPasswordLinkService implements EmailPasswordLinkServi
                 "Email address must be verified before linking password credentials. " +
                 "Call POST /user/me/email/verify first.");
         }
+
+        getPasswordPolicyValidator().validate(password);
 
         return getUserDao().setPassword(uid.getUserId(), password);
     }
@@ -53,6 +57,15 @@ public class SuperUserEmailPasswordLinkService implements EmailPasswordLinkServi
     @Inject
     public void setUserUidDao(UserUidDao userUidDao) {
         this.userUidDao = userUidDao;
+    }
+
+    public PasswordPolicyValidator getPasswordPolicyValidator() {
+        return passwordPolicyValidator;
+    }
+
+    @Inject
+    public void setPasswordPolicyValidator(PasswordPolicyValidator passwordPolicyValidator) {
+        this.passwordPolicyValidator = passwordPolicyValidator;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/user/SuperUserUsernamePasswordLinkService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/SuperUserUsernamePasswordLinkService.java
@@ -22,10 +22,13 @@ public class SuperUserUsernamePasswordLinkService implements UsernamePasswordLin
 
     private UserUidDao userUidDao;
 
+    private PasswordPolicyValidator passwordPolicyValidator;
+
     @Override
     public User linkUsernamePassword(final String username, final String password) {
         final var normalizedUsername = username.trim();
         final var uid = getUserUidDao().getUserUid(normalizedUsername, SCHEME_NAME);
+        getPasswordPolicyValidator().validate(password);
         return getUserDao().setPassword(uid.getUserId(), password);
     }
 
@@ -45,6 +48,15 @@ public class SuperUserUsernamePasswordLinkService implements UsernamePasswordLin
     @Inject
     public void setUserUidDao(UserUidDao userUidDao) {
         this.userUidDao = userUidDao;
+    }
+
+    public PasswordPolicyValidator getPasswordPolicyValidator() {
+        return passwordPolicyValidator;
+    }
+
+    @Inject
+    public void setPasswordPolicyValidator(PasswordPolicyValidator passwordPolicyValidator) {
+        this.passwordPolicyValidator = passwordPolicyValidator;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/user/SuperuserUserService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/SuperuserUserService.java
@@ -43,6 +43,8 @@ public class SuperuserUserService extends AbstractUserService implements UserSer
 
     private PasswordGenerator passwordGenerator;
 
+    private PasswordPolicyValidator passwordPolicyValidator;
+
     private long sessionTimeoutSeconds;
 
     @Override
@@ -76,9 +78,14 @@ public class SuperuserUserService extends AbstractUserService implements UserSer
         getNameService().assignNameAndEmailIfNecessary(user);
 
         // reuse existing DAO method
-        final var password = isNullOrEmpty(userCreateRequest.getPassword())
-            ? getPasswordGenerator().generate()
-            : userCreateRequest.getPassword();
+        final String password;
+
+        if (isNullOrEmpty(userCreateRequest.getPassword())) {
+            password = getPasswordGenerator().generate();
+        } else {
+            getPasswordPolicyValidator().validate(userCreateRequest.getPassword());
+            password = userCreateRequest.getPassword();
+        }
 
         final var created = getUserDao().createUserWithPasswordStrict(user, password);
 
@@ -123,9 +130,14 @@ public class SuperuserUserService extends AbstractUserService implements UserSer
 
         final String password = nullToEmpty(userUpdateRequest.getPassword()).trim();
 
-        final var updated = isNullOrEmpty(password) ?
-            getUserDao().updateUser(user) :
-            getUserDao().updateUser(user, password);
+        final User updated;
+
+        if (isNullOrEmpty(password)) {
+            updated = getUserDao().updateUser(user);
+        } else {
+            getPasswordPolicyValidator().validate(password);
+            updated = getUserDao().updateUser(user, password);
+        }
 
         getElementRegistry().publish(Event.builder()
                 .argument(updated)
@@ -205,6 +217,15 @@ public class SuperuserUserService extends AbstractUserService implements UserSer
     @Inject
     public void setSessionTimeoutSeconds(@Named(SESSION_TIMEOUT_SECONDS) long sessionTimeoutSeconds) {
         this.sessionTimeoutSeconds = sessionTimeoutSeconds;
+    }
+
+    public PasswordPolicyValidator getPasswordPolicyValidator() {
+        return passwordPolicyValidator;
+    }
+
+    @Inject
+    public void setPasswordPolicyValidator(PasswordPolicyValidator passwordPolicyValidator) {
+        this.passwordPolicyValidator = passwordPolicyValidator;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/user/UserEmailPasswordLinkService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/UserEmailPasswordLinkService.java
@@ -18,6 +18,8 @@ public class UserEmailPasswordLinkService implements EmailPasswordLinkService {
 
     private UserUidDao userUidDao;
 
+    private PasswordPolicyValidator passwordPolicyValidator;
+
     @Override
     public User linkEmailPassword(final String email, final String password) {
         final var normalizedEmail = email.trim().toLowerCase();
@@ -32,6 +34,8 @@ public class UserEmailPasswordLinkService implements EmailPasswordLinkService {
                 "Email address must be verified before linking password credentials. " +
                 "Call POST /user/me/email/verify first.");
         }
+
+        getPasswordPolicyValidator().validate(password);
 
         return getUserDao().setPassword(getCurrentUser().getId(), password);
     }
@@ -61,6 +65,15 @@ public class UserEmailPasswordLinkService implements EmailPasswordLinkService {
     @Inject
     public void setUserUidDao(UserUidDao userUidDao) {
         this.userUidDao = userUidDao;
+    }
+
+    public PasswordPolicyValidator getPasswordPolicyValidator() {
+        return passwordPolicyValidator;
+    }
+
+    @Inject
+    public void setPasswordPolicyValidator(PasswordPolicyValidator passwordPolicyValidator) {
+        this.passwordPolicyValidator = passwordPolicyValidator;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/user/UserUserService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/UserUserService.java
@@ -102,6 +102,9 @@ public class UserUserService extends AnonUserService implements UserService {
         final var profileId = userUpdatePasswordRequest.getProfileId();
         final var oldPassword = nullToEmpty(userUpdatePasswordRequest.getOldPassword()).trim();
         final var newPassword = nullToEmpty(userUpdatePasswordRequest.getNewPassword()).trim();
+
+        getPasswordPolicyValidator().validate(newPassword);
+
         final var profile = getProfileDao().findActiveProfileForUser(profileId, userId);
 
         final long expiry = MILLISECONDS.convert(getSessionTimeoutSeconds(), SECONDS) + currentTimeMillis();

--- a/service/src/main/java/dev/getelements/elements/service/user/UserUsernamePasswordLinkService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/UserUsernamePasswordLinkService.java
@@ -23,10 +23,14 @@ public class UserUsernamePasswordLinkService implements UsernamePasswordLinkServ
 
     private Provider<Transaction> transactionProvider;
 
+    private PasswordPolicyValidator passwordPolicyValidator;
+
     @Override
     public User linkUsernamePassword(final String username, final String password) {
         final var normalizedUsername = username.trim();
         final var existingName = getCurrentUser().getName();
+
+        getPasswordPolicyValidator().validate(password);
 
         if (existingName != null && !existingName.isBlank() && !existingName.equals(normalizedUsername)) {
             throw new ForbiddenException(
@@ -93,6 +97,15 @@ public class UserUsernamePasswordLinkService implements UsernamePasswordLinkServ
     @Inject
     public void setTransactionProvider(Provider<Transaction> transactionProvider) {
         this.transactionProvider = transactionProvider;
+    }
+
+    public PasswordPolicyValidator getPasswordPolicyValidator() {
+        return passwordPolicyValidator;
+    }
+
+    @Inject
+    public void setPasswordPolicyValidator(PasswordPolicyValidator passwordPolicyValidator) {
+        this.passwordPolicyValidator = passwordPolicyValidator;
     }
 
 }


### PR DESCRIPTION
## Summary
- New deploy-time config: `dev.getelements.elements.password.policy.regex` (default `.{4,}`) and `dev.getelements.elements.password.policy.description` (default `"Password must be at least 4 characters."`), added to `Constants`/`CommonModuleDefaults`.
- New `PasswordPolicyValidator` (`service/`), enforcing the regex and raising `InvalidParameterException(description)` on mismatch.
- Wired into every client-facing password-accepting path: signup (`AnonUserService`, `SuperuserUserService.createUser`), admin-set/self-service password change (`SuperuserUserService.updateUser`, `UserUserService.updateUserPassword`), password reset completion (`AbstractPasswordResetService`), and all four email/username+password linking service implementations.
- Server-generated passwords (bootstrap default superuser, mock/test accounts) are intentionally exempt.
- Default regex (`.{4,}`) is sized to match the length of the built-in default superuser password so a fresh deployment never violates its own policy.

Fixes #5.

## Test plan
- [x] `mvn -pl service -am compile` clean
- [x] `mvn -pl service-test test` (fixed 3 existing tests whose hand-rolled Guice `TestModule`s needed the new config bindings)
- [x] Full `jetty-ws-test` REST integration suite: 1652/1652 passing, confirming no existing fixture password is shorter than 4 characters
